### PR TITLE
Nixos fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /nix/local
 /opam2nix.install
 /bin
+**/.gup

--- a/build-nix.sh
+++ b/build-nix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 gup="$(nix-build --show-trace --no-out-link ./nix/gup.nix)"
 [ -n "$gup" ] || exit 1

--- a/local.gup
+++ b/local.gup
@@ -1,5 +1,4 @@
 #!bash -eux
 gup -u nix/local.tgz
 nix-build --out-link "$1" nix/local.nix --show-trace
-touch "$1"
 readlink "$1" | gup --contents

--- a/nix/local.tgz.gup
+++ b/nix/local.tgz.gup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 # Print the current HEAD or working copy (as a stash)
 # (returns the same hash for unchanged content, due to the overridden GIT_* variables below)


### PR DESCRIPTION
Various fixes to have `gup` work on this repo on nixos.
this partially addresses https://github.com/timbertson/opam2nix-packages/issues/8