### PR TITLE
Fixes for a couple of bugs I ran into

### DIFF
--- a/src/generate.ml
+++ b/src/generate.ml
@@ -147,7 +147,7 @@ let main arg_idx args =
 		let version_dir = String.concat Filename.dir_sep (dest :: dest_parts) in
 		let dest_path = Filename.concat version_dir "default.nix" in
 		let files_src = (Filename.concat path "files") in
-		let has_files = try let (_:Unix.stats) = Unix.stat files_src in true with Unix.Unix_error (Unix.ENOENT, _, _) -> false in
+		let has_files = Sys.file_exists files_src in
 		let expr = generate_expr ~mode ~path:dest_path (fun () ->
 			let handle_error desc e =
 				if !ignore_broken_packages then (
@@ -167,7 +167,7 @@ let main arg_idx args =
 			let open FileUtil in
 			cp [readlink (Filename.concat path "opam")] (Filename.concat version_dir "opam");
 			let () =
-				let filenames = if Sys.file_exists files_src then ls files_src else [] in
+				let filenames = if has_files then ls files_src else [] in
 				match filenames with
 					| [] -> ()
 					| filenames ->

--- a/src/invoke.ml
+++ b/src/invoke.ml
@@ -228,7 +228,7 @@ let execute_install_file state =
 	install_files false destDir "man" OpamFile.Dot_install.man;
 
 	(* Shared files *)
-	install_files false destDir "share" OpamFile.Dot_install.share;
+	install_files false destDir (Filename.concat "share" name) OpamFile.Dot_install.share;
 	install_files false destDir "share" OpamFile.Dot_install.share_root;
 
 	(* Etc files *)


### PR DESCRIPTION
The first one involves a test for file existence which somehow was producing results inconsistent with Sys.file_exists which was being used farther down in the same code.

The second is that files that needed to be installed to the 'share' weren't being installed to the subdirectory of that according to the package name as given here:

https://opam.ocaml.org/doc/Manual.html#Package-specification

"share: installs to \<prefix\>/share/package-name"