### PR TITLE
Some tweaks for better package support

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -15,7 +15,7 @@ let () =
 		let open Op in
 		Dir.of_string (Filename.get_temp_dir_name ()) / "opam2nix"
 	) ();
-	if Array.length Sys.argv = 0 then (
+	if Array.length Sys.argv <= 1 then (
 		eprintf "Usage: opam2nix <command> [args]\n\nAvailable commands: %s"
 		(commands |> List.map (fun (name, _) -> name) |> String.concat ", ");
 		exit 1

--- a/src/opam_metadata.ml
+++ b/src/opam_metadata.ml
@@ -426,8 +426,10 @@ let init_variables () =
 	state
 		|> add_var "os" (S (os_string ()))
 		|> add_var "make" (S "make")
-		|> add_var "opam-version" (S (OpamVersion.to_string OpamVersion.current))
-		|> add_var "preinstalled" (B false) (* XXX ? *)
+                |> add_var "opam-version" (S (OpamVersion.to_string OpamVersion.current))
+                (* With preinstalled packages suppose they can't write
+                   in the ocaml directory *)
+		|> add_var "preinstalled" (B true)
 		|> add_var "pinned" (B false) (* probably ? *)
 		|> add_var "jobs" (S "1") (* XXX NIX_JOBS? *)
 		(* XXX best guesses... *)

--- a/src/opam_metadata.ml
+++ b/src/opam_metadata.ml
@@ -337,7 +337,7 @@ let nix_of_opam ~name ~version ~cache ~offline ~deps ~has_files path : Nix_expr.
 	let property_of_input src (name, importance) : Nix_expr.t =
 		match importance with
 			| Optional -> `Property_or (src, name, `Null)
-			| Required -> `Property (src, name)
+			| Required -> `PropertyPath (src, String.split_on_char '.' name)
 	in
 	let attr_of_input src (name, importance) : string * Nix_expr.t =
 		(name, property_of_input src (name, importance))


### PR DESCRIPTION
This MR adds some tweaks for better support of packages:
* consider that the depext for nixpkgs is a path so that we can use `gnome2.sourceview` (eg. conf-gtksourceview)
* set the preinstalled variable so that package consider they can't be installed in the ocaml directory (usually they then use ocamlfind) (eg. num with OCaml `>= 4.06 `).

My repository of opam-repository contains updated  version of the packages for opam2nix. I'm going to ask for merge after at least the first point is accepted here.