### PR TITLE
Make bundled files writeable

### DIFF
--- a/src/invoke.ml
+++ b/src/invoke.ml
@@ -295,7 +295,7 @@ let patch env =
 		let contents = Sys.readdir files_path
 			|> Array.map (Filename.concat files_path) in
 		Lwt_main.run (Cmd.(run_unit_exn exec_none) (List.concat [
-			[ "cp"; "-r" ];
+			[ "cp"; "-r"; "--no-preserve=mode"; "--dereference" ];
 			Array.to_list contents;
 			[ "./" ]
 		])


### PR DESCRIPTION
Files under `/files` in the opam repository are correctly copied in the
working tree when building a package, however they are copied as a
read-only link to a (read-only) file in the store, which means that the
build will fail if it tries to modify one of these (contrary to plain
opam which works just fine in that case).

Change that to
- dereference the symlinks to copy the actual files
- not preserve the RO mode so that the build can modify these files if needed