### PR TITLE
disable gtk

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -72,7 +72,10 @@ let
 			}
 		) {};
 
-		ocamlgraph = callOcamlPackage <nixpkgs/pkgs/development/ocaml-modules/ocamlgraph/default.nix> { lablgtk = null; };
+		ocamlgraph = callOcamlPackage <nixpkgs/pkgs/development/ocaml-modules/ocamlgraph/default.nix> {
+			lablgtk = null;
+			gtkSupport = false;
+		};
 	};
 
 in callOcamlPackage ./opam2nix.nix { inherit self; }


### PR DESCRIPTION
Fix for the issue I mentioned here https://github.com/timbertson/opam2nix/issues/31#issuecomment-683349722, where ocamlgraph tries to build with gtk, due to a missing flag recently added that's required to disable it.