### PR TITLE
Set the os-family otherwise the one from the host is used

### DIFF
--- a/src/opam_metadata.ml
+++ b/src/opam_metadata.ml
@@ -103,6 +103,7 @@ let native_system_vars () =
 
 let nixos_vars () =
 	native_system_vars ()
+		|> add_global_var "os-family" (S "unknown")
 		|> add_global_var "os-distribution" (S "nixos")
 		|> add_global_var "os-version" (S "unknown")
 			(* I don't think we can easily get a number here, but it should


### PR DESCRIPTION
Since the `native_system_var` are used `os-family` can be `debian`