### PR TITLE
Set useDune2 when building Opam libraries

### DIFF
--- a/nix/opam.nix
+++ b/nix/opam.nix
@@ -3,10 +3,11 @@ let
 	base = name: {
 		propagatedBuildInputs ? [],
 		buildInputs ? [],
+		useDune2 ? true,
 		... } @ attrs: attrs // {
 		pname = "opam-${name}";
 		version = "dev";
-		inherit buildInputs propagatedBuildInputs src;
+		inherit useDune2 buildInputs propagatedBuildInputs src;
 		configureFlags = "--disable-checks";
 	};
 in


### PR DESCRIPTION
Build failed when Dune was looking up 'dune-project' files from dependencies that were compiled with Dune 2.

This is caused by a recent change in nixpkgs that sets 'useDune2' on the 're' library.