### PR TITLE
Improve attr sets handling

### DIFF
--- a/src/nix_expr.ml
+++ b/src/nix_expr.ml
@@ -109,20 +109,22 @@ let write dest (t:t) =
 		in
 		let property name = put ("." ^ (escape_key name)) in
 
-		let write_inherit expr keys =
-			nl ();
-			put "inherit";
-			space ();
-			begin match expr with
-				| None -> ();
-				| Some expr ->
-					put "(";
-					_write expr;
-					put ")";
-					space ();
-			end;
-			pp_print_list pp_print_string ~pp_sep:pp_print_space formatter keys;
-			put ";"
+		let write_inherit expr = function
+			| [] -> ()
+			| keys ->
+				nl ();
+				put "inherit";
+				space ();
+				begin match expr with
+					| None -> ();
+					| Some expr ->
+						put "(";
+						_write expr;
+						put ")";
+						space ();
+				end;
+				pp_print_list pp_print_string ~pp_sep:pp_print_space formatter keys;
+				put ";"
 		in
 
 		let write_attrs ~prefix a =

--- a/src/opam_metadata.ml
+++ b/src/opam_metadata.ml
@@ -322,9 +322,11 @@ let nix_of_opam ~pkg ~deps ~(opam_src:opam_src) ~opam ~src ~url () : Nix_expr.t 
 		|> List.sort (fun (a,_) (b,_) -> String.compare a b)
 	in
 
-	let opam_inputs : Nix_expr.t AttrSet.t =
+	let opam_inputs : Nix_expr.attrset =
 		!opam_inputs |> InputMap.mapi (fun name importance ->
-			property_of_input (`Id "selection") (name, importance)) in
+			property_of_input (`Id "selection") (name, importance))
+        |> InputMap.bindings |> List.map (fun (k, v) -> `Expr (k, v))
+ in
 
 	let nix_deps = !nix_deps
 		|> sorted_bindings_of_input

--- a/src/select.ml
+++ b/src/select.ml
@@ -205,10 +205,10 @@ let write_solution ~external_constraints ~cache  ~universe installed dest =
 	) new_packages AttrSet.empty in
 
 	let attrs = [
-		"format-version", `Int 4;
-		"repos", `Id "repos";
-		"ocaml-version", str (external_constraints.ocaml_version |> Version.to_string);
-		"selection", `Attrs selection
+		`Expr ("format-version", `Int 4);
+		`Inherit (None, ["repos"]);
+		`Expr ("ocaml-version", str (external_constraints.ocaml_version |> Version.to_string));
+		`Expr ("selection", `Attrs selection)
 	] in
 
 	let sha256 digest = Lwt_main.run digest |> fun (`sha256 x) -> x in
@@ -239,7 +239,7 @@ let write_solution ~external_constraints ~cache  ~universe installed dest =
 			"repoPath", `Lit "self.repoPath";
 			"repos", `Attrs (AttrSet.build repo_attrsets);
 		],
-		`Attrs (AttrSet.build attrs);
+		`Attrs attrs;
 	)) in
 	Lwt_main.run (Digest_cache.save cache);
 	let oc = open_out dest in


### PR DESCRIPTION
First, I change the representation of attr sets to a list of bindings. This
allows me to support `inherit`, and it preserves the order of bindings provided
by the user. The fact that attributes are always sorted seems to be surprising
and unnecessary. 

Then, I use the new representation to simplify how opam-selection is generated.
In particular, `opamInputs` is usually much less redundant now.