### PR TITLE
Provide full path in opam-selection.nix instead of filename

### DIFF
--- a/src/select.ml
+++ b/src/select.ml
@@ -332,7 +332,7 @@ let main idx args =
 			direct_name = name;
 			direct_version = opam.version;
 			direct_opam = opam;
-			direct_opam_relative = opam_filename;
+			direct_opam_relative = path;
 		}
 	in
 


### PR DESCRIPTION
Hi,
I compiled https://github.com/mirage/mirage-skeleton with opam2nix. 
Because of that project layout it would be convenient to have opam2nix pickup the full path to the opam file, as given via the resolve command. 
This patch is doing exactly this.

Disclaimer: First time user here. I don't know whether this change has any implications on other use cases.