### PR TITLE
digest_cache.mli

### DIFF
--- a/src/digest_cache.ml
+++ b/src/digest_cache.ml
@@ -67,7 +67,7 @@ let key_of_opam_digest digest =
 	(digest |> OpamHash.kind |> OpamHash.string_of_kind |> String.lowercase_ascii)
 		^ ":" ^ (digest |> OpamHash.contents)
 
-let opam_digest_of_key key =
+let _opam_digest_of_key key =
 	match String.split_on_char ':' key with
 		| ["md5"; digest] -> OpamHash.md5 digest
 		| ["sha256"; digest] -> OpamHash.md5 digest

--- a/src/digest_cache.mli
+++ b/src/digest_cache.mli
@@ -1,0 +1,30 @@
+type key = string
+
+type opam_digest = OpamHash.t
+
+type t
+
+type nix_digest = [
+	| `sha256 of string
+]
+
+type checksum_mismatch = [ `checksum_mismatch of string ]
+
+type unknown_error = [ `error of string ]
+
+type error = [
+	| checksum_mismatch
+	| Cmd.command_failed
+	| Download.error
+	| unknown_error
+]
+
+val add : key -> opam_digest list -> t -> (nix_digest, error) result Lwt.t
+
+val add_custom : t -> keys:key list -> (unit -> (nix_digest, error) result Lwt.t) -> (nix_digest, error) result Lwt.t
+
+val save : t -> unit Lwt.t
+
+val try_load : key -> t
+
+val string_of_error : error -> string


### PR DESCRIPTION
Hi,

I added this mli because it helped me understand the code base. I understand that you might not like the redundancy of mli's, but they do offer a number of advantages:

* They hide private functions and types
* Faster compilation
* Easier for readers to grok the public interface
* Detection of dead code

If you don't want this PR, that's not a big issue. But there's a reason mli's are so widespread in the OCaml world. It would at the very least make it easier for contributors to jump in.