### PR TITLE
Set OPAM_SWITCH_PREFIX during build

### DIFF
--- a/src/invoke.ml
+++ b/src/invoke.ml
@@ -263,5 +263,6 @@ let main idx args =
 		| None -> failwith "No action given"
 	in
 	Unix.putenv "PREFIX" (destDir () |> OpamFilename.Dir.to_string);
+	Unix.putenv "OPAM_SWITCH_PREFIX" (destDir () |> OpamFilename.Dir.to_string);
 	action (load_env ())
 


### PR DESCRIPTION
Dune requires this when using generated dune files with dune-lang 2.9.

Tested using this `flake.nix`:

```nix
{
  inputs = {
    nixpkgs.url = "nixpkgs";

    opam2nix-src = {
      url = "github:timbertson/opam2nix/v1";
      #url = "github:talex5/opam2nix/opam-switch-prefix";
      flake = false;
    };
  };

  outputs = { self, nixpkgs, opam2nix-src }:
  let
    system = "x86_64-linux";
    pkgs = nixpkgs.legacyPackages.${system};
    opam2nix = import opam2nix-src { inherit pkgs; };
    ocaml5 = pkgs.ocaml-ng.ocamlPackages_5_0.ocaml;
    selection =
      opam2nix.build {
        ocaml = ocaml5 // { version = "5.0.0"; };
        selection = ./opam-selection.nix;
      };
  in
  {
    packages.${system}.default = selection.eio_main;
  };
}
```

and these commands:

```
opam2nix resolve --ocaml-version 5.0.0~beta1 eio_main
nix build . --impure
```

This fails with:

```
       >  + dune build -p eio -j 8 --promote-install-files=false @install
       >  + dune install -p eio --create-install-files eio
       > Error: The mandir installation directory is unknown.
       > Hint: It could be specified with --mandir
       > Command failed.
```

Changing the URL for opam2nix to reference this PR's branch fixes it.

( However, I'm not entirely sure that this value is correct since the build still works even if it's set to a different value. )